### PR TITLE
Add feature enable/disable switch to the extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -21,9 +21,18 @@ function updateTabs() {
 
 // פונקציה לעדכון טאב בודד
 function updateTab(tabId) {
-    chrome.storage.sync.get(['mode', 'blacklist', 'whitelist'], function (data) {
+    chrome.storage.sync.get(['mode', 'blacklist', 'whitelist', 'enabled'], function (data) {
         const mode = data.mode || 'blacklist';
         const list = mode === 'blacklist' ? data.blacklist || [] : data.whitelist || [];
+        const enabled = data.enabled !== false;
+
+        if (!enabled) {
+            chrome.scripting.executeScript({
+                target: { tabId: tabId },
+                func: () => document.documentElement.classList.remove('inv')
+            });
+            return;
+        }
 
         chrome.tabs.get(tabId, function(tab) {
             const shouldApply = mode === 'blacklist' ? !list.includes(new URL(tab.url).hostname) : list.includes(new URL(tab.url).hostname);

--- a/content.js
+++ b/content.js
@@ -3,10 +3,13 @@ document.addEventListener("DOMContentLoaded", function() {
 
     // הפעלת הפונקציה מידית על כל דף בהתאם לרשימות וההגדרות
     (function() {
-        chrome.storage.sync.get(['mode', 'blacklist', 'whitelist'], function (data) {
+        chrome.storage.sync.get(['mode', 'blacklist', 'whitelist', 'enabled'], function (data) {
             const mode = data.mode || 'blacklist';
             const list = mode === 'blacklist' ? data.blacklist || [] : data.whitelist || [];
             const currentHost = window.location.hostname;
+            const enabled = data.enabled !== false;
+
+            if (!enabled) return;
 
             const shouldApply = mode === 'blacklist' ? !list.includes(currentHost) : list.includes(currentHost);
 

--- a/popup.html
+++ b/popup.html
@@ -91,6 +91,13 @@
     </style>
 </head>
 <body>
+    <div class="switch-container">
+        <h3>Enabled:</h3>
+        <label class="switch">
+            <input type="checkbox" id="enable-disable-toggle">
+            <span class="slider"></span>
+        </label>
+    </div>
     <div>
         <h3>Mode Selection</h3>
         <select id="mode">

--- a/popup.js
+++ b/popup.js
@@ -1,10 +1,15 @@
 document.addEventListener('DOMContentLoaded', function () {
     const modeSelect = document.getElementById('mode');
+    const enableDisableToggle = document.getElementById('enable-disable-toggle');
     const siteToggle = document.getElementById('site-toggle');
     const urlListDiv = document.getElementById('url-list');
     // Load saved mode and URL lists
-    chrome.storage.sync.get(['mode', 'blacklist', 'whitelist'], function (data) {
+    chrome.storage.sync.get(['mode', 'blacklist', 'whitelist', 'enabled'], function (data) {
         const mode = data.mode || 'blacklist';
+        const enabled = data.enabled !== false;
+        enableDisableToggle.checked = enabled;
+        modeSelect.disabled = !enabled;
+        siteToggle.disabled = !enabled;
         modeSelect.value = mode;
         updateUrlList(mode, data.blacklist, data.whitelist);
         updateSiteToggle(mode, data.blacklist, data.whitelist);
@@ -18,6 +23,23 @@ document.addEventListener('DOMContentLoaded', function () {
             updateUrlList(mode, data.blacklist, data.whitelist);
             updateSiteToggle(mode, data.blacklist, data.whitelist);
             applySiteSettings(mode);
+        });
+    });
+
+    // Handle enable/disable toggle change
+    enableDisableToggle.addEventListener('change', function () {
+        const enabled = enableDisableToggle.checked;
+        modeSelect.disabled = !enabled;
+        siteToggle.disabled = !enabled;
+        chrome.storage.sync.set({ enabled: enabled }, function () {
+            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+                if (tabs.length > 0) {
+                    chrome.scripting.executeScript({
+                        target: { tabId: tabs[0].id },
+                        func: enabled ? applyNegativeColors : removeNegativeColors
+                    });
+                }
+            });
         });
     });
 
@@ -90,7 +112,15 @@ function applySiteSettings(mode) {
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         if (tabs.length > 0) {
             const url = new URL(tabs[0].url).hostname;
-            chrome.storage.sync.get([mode], function (data) {
+            chrome.storage.sync.get([mode, 'enabled'], function (data) {
+                const enabled = data.enabled !== false;
+                if (!enabled) {
+                    chrome.scripting.executeScript({
+                        target: { tabId: tabs[0].id },
+                        func: removeNegativeColors
+                    });
+                    return;
+                }
                 const list = data[mode] || [];
                 console.log('Current List:', list);
                 console.log('Mode:', mode);


### PR DESCRIPTION
This PR adds a global enable/disable toggle switch to the popup interface.

The switch allows users to easily enable or disable the extension without removing it from Chrome.

Changes:
- Added toggle switch to popup UI
- Stored enabled state in chrome.storage.sync
- Updated background and content scripts to respect enabled state
- Disabled popup controls when extension is turned off

The extension now immediately removes the effect from pages when disabled and restores it when re-enabled.